### PR TITLE
修复排版错误

### DIFF
--- a/chen_cppcguilib/basicProgressBar.cpp
+++ b/chen_cppcguilib/basicProgressBar.cpp
@@ -22,15 +22,18 @@ int basicProgressBar::getHeight() const
 std::vector<std::string> basicProgressBar::getData() const
 {
 	string ret = "";
-	double actualLength = ((double)progress / 100.0) * (length);
-	ret += startChar;
-	for (double i = 1; i <= actualLength; i += 1)
-		ret += fillChar;
-	if (progress != 100)
-	{
-		ret += seqChar;
-		for (double i = 1; i <= (length - actualLength); i++)
+	int fillCount = (int)((double)progress * (double)(length - 2) / 100.0);
+	ret += beginChar;
+	for (int i = 0; i < length - 2; ++i) {
+		if (i < fillCount) {
+			ret += fillChar;
+		}
+		else if (i == fillCount) {
+			ret += seqChar;
+		}
+		else {
 			ret += gapChar;
+		}
 	}
 	ret += endChar;
 	return { ret };

--- a/chen_cppcguilib/basicProgressBar.h
+++ b/chen_cppcguilib/basicProgressBar.h
@@ -16,5 +16,5 @@ public:
 
 private:
 	int length, style, progress;
-	char startChar = '[', fillChar = '=', seqChar = '>', gapChar = ' ', endChar = ']';
+	char beginChar = '[', fillChar = '=', seqChar = '>', gapChar = ' ', endChar = ']';
 };

--- a/chen_cppcguilib/cgui.h
+++ b/chen_cppcguilib/cgui.h
@@ -8,10 +8,10 @@
 #include <string>
 #include <vector>
 
-struct pos {
+struct logicPos {
     int row, col;
 };
-static bool operator<(const pos& lhs, const pos& rhs) {
+static bool operator<(logicPos lhs, logicPos rhs) {
     return (lhs.row < rhs.row) || (lhs.row == rhs.row && lhs.col < rhs.col);
 }
 
@@ -23,21 +23,25 @@ public:
     void update();
 
     //把某个控件放到...
-    void setTo(int row, int col, std::shared_ptr<component> src);
+    void setTo(logicPos pos, std::shared_ptr<component> src);
 
     //清空控件
     void clear();
 
 private:
-    std::map<pos, std::shared_ptr<component>> components;
+    std::map<logicPos, std::shared_ptr<component>> components;
     // 获得组件上方一个组件的高
-    int getUpperComponentHeight(const pos& current);
+    int getUpperComponentHeight(logicPos current);
     // 获得组件上方所有组件的高的总和
-    int getAboveComponentHeight(const pos& current);
+    int getAboveComponentHeight(logicPos current);
     // 获得左边组件的宽
-    int getLeftComponentWidth(const pos& current);
+    int getLeftComponentWidth(logicPos current);
     // 获得左边所有低于自身组件的宽，碰到同行的也停止
-    int getAllLeftComponentWidth(const pos& current, int row);
+    int getAllLeftComponentWidth(logicPos current, int row);
     // 获得左边组件的高
-    int getLeftComponentHeight(const pos& current);
+    int getLeftComponentHeight(logicPos current);
+    // 找最近的存在的组件，y表示每次向下走格数，x表示每次向右走格数，可以为负，有则返回位置，无则返回-1,-1
+    logicPos findNearestComponent(logicPos current, int y, int x);
+    // 判断位置是不是不合理的
+    bool isBadLogicPos(logicPos pos);
 };

--- a/sandbox/main.cpp
+++ b/sandbox/main.cpp
@@ -61,11 +61,11 @@ int main() {
     vector<string> multiText = { "hello","world","CGUI!" };
     auto multiLine = std::make_shared<multiLineText>(multiText);
 
-    p.setTo(0, 0, image);
-    p.setTo(1, 0, std::make_shared<basicText>("\033[38;2;255;0;0mRed Text\033[0m"));
-    p.setTo(0, 1, std::make_shared<basicText>("Hello World!"));
-    p.setTo(2, 0, progressBar);
-    p.setTo(2, 1, multiLine);
+    p.setTo({ 0, 0 }, image);
+    p.setTo({ 1, 0 }, std::make_shared<basicText>("\033[38;2;255;0;0mRed Text\033[0m"));
+    p.setTo({ 0, 1 }, std::make_shared<basicText>("Hello World!"));
+    p.setTo({ 2, 0 }, progressBar);
+    p.setTo({ 2, 1 }, multiLine);
     p.update();
 
     while (!progressBar->isDone()) {
@@ -79,17 +79,17 @@ int main() {
 
     auto space = make_shared<basicText>("   ");
 
-    p.setTo(0, 0, image);
-    p.setTo(0, 1, space);
-    p.setTo(0, 2, make_shared<basicImage>(bigChar('C')));
-    p.setTo(0, 3, space);
-    p.setTo(0, 4, make_shared<basicImage>(bigChar('G')));
-    p.setTo(0, 5, space);
-    p.setTo(0, 6, make_shared<basicImage>(bigChar('U')));
-    p.setTo(0, 7, space);
-    p.setTo(0, 8, make_shared<basicImage>(bigChar('I')));
-    p.setTo(0, 9, space);
-    p.setTo(0, 10, image);
+    p.setTo({ 0, 0 }, image);
+    p.setTo({ 0, 1 }, space);
+    p.setTo({ 0, 2 }, make_shared<basicImage>(bigChar('C')));
+    p.setTo({ 0, 3 }, space);
+    p.setTo({ 0, 4 }, make_shared<basicImage>(bigChar('G')));
+    p.setTo({ 0, 5 }, space);
+    p.setTo({ 0, 6 }, make_shared<basicImage>(bigChar('U')));
+    p.setTo({ 0, 7 }, space);
+    p.setTo({ 0, 8 }, make_shared<basicImage>(bigChar('I')));
+    p.setTo({ 0, 9 }, space);
+    p.setTo({ 0, 10 }, image);
     p.update();
 
     return 0;


### PR DESCRIPTION
对于上方无组件的情况，应该对齐左侧的组件
![image](https://github.com/user-attachments/assets/d4b68e39-4d7e-4306-a341-626258d70f2f)
（修复后的输出）

修复了progressBar的实际宽度和getWidth()返回值不一致问题

把pos更名为了logicPos。setTo函数的row和col改为logicPos