### PR TITLE
修复string::take和takeComplete的Bug

### DIFF
--- a/include/cgui/utils/string.h
+++ b/include/cgui/utils/string.h
@@ -3,6 +3,17 @@
 
 namespace cgui {
 
+struct Char {
+    // 读取src首个Utf8字符 / ANSI颜色转义序列
+    Char(const char* src);
+    // Char的字节数
+    size_t getSize() const;
+    // Char的宽度
+    size_t getWidth() const;
+
+    const char* p;
+};
+
 // 一个没有\n \t，结尾会自动添加“恢复默认颜色”的字符串
 class string {
 public:
@@ -53,14 +64,26 @@ public:
     string& operator=(const string& other);
     string& operator=(std::string_view other);
 
+    // 迭代器
+    struct iterator {
+        iterator& operator++();
+        bool operator==(const iterator& other) const;
+        Char operator*() const;
+        operator char* ();
+
+        char* p; // => cgui::string::bytes
+    };
+    iterator begin();
+    iterator end();
+
 private:
-    std::string str;
-    size_t visibleLength = 0;
+    std::string bytes;
+    size_t width = 0;
 
     // 返回末尾的“恢复默认颜色”的前面一个位置
     size_t pushBackPos() const;
     // 计算可见字符的宽度
-    void calculateVisibleLength();
+    void calculateWidth();
     // rgb转换为ANSI转义序列
     std::string colorAnsiEscapeCode(int mod, int r, int g, int b);
 };

--- a/include/cgui/utils/string.h
+++ b/include/cgui/utils/string.h
@@ -82,6 +82,8 @@ private:
 
     // 返回末尾的“恢复默认颜色”的前面一个位置
     size_t pushBackPos() const;
+    // 移除\n \t
+    void removeBadChar();
     // 计算可见字符的宽度
     void calculateWidth();
     // rgb转换为ANSI转义序列

--- a/include/cgui/utils/string.h
+++ b/include/cgui/utils/string.h
@@ -3,17 +3,6 @@
 
 namespace cgui {
 
-struct Char {
-    // 读取src首个Utf8字符 / ANSI颜色转义序列
-    Char(const char* src);
-    // Char的字节数
-    size_t getSize() const;
-    // Char的宽度
-    size_t getWidth() const;
-
-    const char* p;
-};
-
 // 一个没有\n \t，结尾会自动添加“恢复默认颜色”的字符串
 class string {
 public:
@@ -68,7 +57,7 @@ public:
     struct iterator {
         iterator& operator++();
         bool operator==(const iterator& other) const;
-        Char operator*() const;
+        char* operator*() const;
         operator char* ();
 
         char* p; // => cgui::string::bytes

--- a/sandbox/demo.cpp
+++ b/sandbox/demo.cpp
@@ -60,51 +60,50 @@ static void initFont() {
 int main() {
     initFont();
 
-    auto image = std::make_shared<basicImage>(getImageByLines("../../asserts/textures/apple.png"));
     auto space = std::make_shared<basicText>("   ");
-    auto title = std::make_shared<hContainer>(hContainer{
-        image, 
-        space,
-        std::make_shared<basicImage>(bigChar('C')),
-        space,
-        std::make_shared<basicImage>(bigChar('G')),
-        space,
-        std::make_shared<basicImage>(bigChar('U')),
-        space,
-        std::make_shared<basicImage>(bigChar('I')),
-        space
-        });
-    
     auto progressBar = std::make_shared<basicProgressBar>(10, 0);
     auto progressBar1 = std::make_shared<basicProgressBar>(15, 1);
     auto progressBar2 = std::make_shared<basicProgressBar>(20, 2);
     auto progressBar3 = std::make_shared<basicProgressBar>(25, 2);
-    auto progressBars = std::make_shared<vContainer>(vContainer{
-        progressBar,
-        progressBar1,
-        progressBar2,
-        progressBar3
-        });
-
-    std::vector<cgui::string> multiText = { "Red Red Red","Green Green Green","Blue Blue Blue" };
+    std::vector<cgui::string> multiText = { 
+        "CGUI是跨平台的控制台UI库",
+        "CGUI支持UTF8字符：あ감ڠ😊⨌",
+        "CGUI支持彩色字符"
+    };
     multiText[0].insertRGB(0, 255, 0, 0);
     multiText[1].insertRGB(0, 0, 255, 0);
     multiText[2].insertRGB(0, 0, 0, 255);
-    auto multiLine = std::make_shared<multiLineText>(multiText);
-    auto line1 = std::make_shared<hContainer>(hContainer{ 
-        multiLine,
-        std::make_shared<basicText>("progress bars:"),
-        progressBars
-        });
-
-    auto dev1 = std::make_shared<vContainer>(vContainer{
-        title,
-        line1
-        });
 
     page p;
-    p.set({ 0, 0 }, dev1);
-    p.set({ 0, 1 }, image);
+    p.set({ 0, 0 }, 
+        std::make_shared<vContainer>(vContainer{
+            std::make_shared<hContainer>(hContainer{
+                std::make_shared<basicImage>(getImageByLines("../../asserts/textures/diamond_sword.png")),
+                space,
+                std::make_shared<basicImage>(bigChar('C')),
+                space,
+                std::make_shared<basicImage>(bigChar('G')),
+                space,
+                std::make_shared<basicImage>(bigChar('U')),
+                space,
+                std::make_shared<basicImage>(bigChar('I')),
+                space
+            }),
+            std::make_shared<hContainer>(hContainer{
+                std::make_shared<basicText>("progress bars:"),
+                std::make_shared<vContainer>(vContainer{
+                    progressBar,
+                    progressBar1,
+                    progressBar2,
+                    progressBar3
+                })
+            })
+        }));
+    p.set({ 0, 1 }, std::make_shared<vContainer>(vContainer{
+        std::make_shared<multiLineText>(multiText),
+        std::make_shared<basicImage>(getImageByLines("../../asserts/textures/apple.png"))
+        }));
+
     while (true) {
         p.update();
         std::this_thread::sleep_for(500ms);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -95,7 +95,7 @@ void page::update() const
             buffer += '\n';
         }
     }
-    std::cout << "\x1B[?25l\x1B[0;0H" << buffer;
+    printf("\x1B[?25l\x1B[0;0H%s", buffer.data());
 }
 
 void page::set(cgui::logicPos pos, std::shared_ptr<component> src)

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -42,20 +42,6 @@ static size_t charWidth(const char* src) {
     return wts8width(src, ret);
 }
 
-cgui::Char::Char(const char* src)
-    : p(src)
-{}
-
-size_t cgui::Char::getSize() const
-{
-    return charSize(p);
-}
-
-size_t cgui::Char::getWidth() const
-{
-    return charWidth(p);
-}
-
 cgui::string::string()
     : bytes(defaultColor)
 {}
@@ -253,7 +239,7 @@ void cgui::string::calculateWidth()
 {
     width = 0;
     for (auto c : *this) {
-        width += c.getWidth();
+        width += charWidth(c);
     }
 }
 
@@ -283,9 +269,9 @@ bool cgui::string::iterator::operator==(const iterator& other) const
     return p == other.p;
 }
 
-cgui::Char cgui::string::iterator::operator*() const
+char* cgui::string::iterator::operator*() const
 {
-    return Char(p);
+    return p;
 }
 
 cgui::string::iterator::operator char* ()

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -120,17 +120,19 @@ void cgui::string::appendDirectly(const string& other)
 
 cgui::string cgui::string::take(size_t n) {
     auto it = begin();
+    auto last = it;
     size_t currentWidth = 0;
     for (; (currentWidth < n) && (it != end()); ++it) {
+        last = it;
         currentWidth += charWidth(it);
     }
     if (currentWidth == n) {
         return { std::string(begin().p, it.p).data() };
     }
     else if (currentWidth > n) {
-        currentWidth -= charWidth(it);
+        currentWidth -= charWidth(last);
     }
-    std::string ret(begin().p, it.p);
+    std::string ret(begin().p, last.p);
     ret += std::string(n - currentWidth, cgui::getPaddingChar());
     return { ret.data() };
 }
@@ -138,14 +140,19 @@ cgui::string cgui::string::take(size_t n) {
 cgui::string cgui::string::takeComplete(size_t n)
 {
     auto it = begin();
+    auto last = it;
     size_t currentWidth = 0;
     for (; (currentWidth < n) && (it != end()); ++it) {
+        last = it;
         currentWidth += charWidth(it);
     }
-    if (currentWidth >= n) {
+    if (currentWidth == n) {
         return { std::string(begin().p, it.p).data() };
     }
-    std::string ret(begin().p, it.p);
+    else if (currentWidth > n) {
+        currentWidth -= charWidth(last);
+    }
+    std::string ret(begin().p, last.p);
     ret += std::string(n - currentWidth, cgui::getPaddingChar());
     return { ret.data() };
 }

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -4,15 +4,67 @@
 
 static const std::string defaultColor = "\x1b[0m";
 
+static size_t utf8CharSize(char firstByte) {
+    if ((firstByte & 0x80) == 0x00) return 1;
+    else if ((firstByte & 0xE0) == 0xC0) return 2;
+    else if ((firstByte & 0xF0) == 0xE0) return 3;
+    else if ((firstByte & 0xF8) == 0xF0) return 4;
+    else return 0;
+}
+
+static size_t charSize(const char* src) {
+    if (!src) {
+        return 0;
+    }
+    if (src[0] == '\x1b') {
+        size_t ret = 1;
+        for (; src[ret] != 0; ++ret) {
+            if (src[ret] == 'm') {
+                return ret + 1;
+            }
+        }
+        return ret;
+    }
+    size_t ret = 0;
+    for (; (ret < utf8CharSize(src[0])) && (src[ret] != 0 && src[ret] != '\x1b'); ++ret);
+    return ret;
+}
+
+static size_t charWidth(const char* src) {
+    if (!src) {
+        return 0;
+    }
+    if (src[0] == '\x1b') {
+        return 0;
+    }
+    size_t ret = 0;
+    for (; (ret < utf8CharSize(src[0])) && (src[ret] != 0 && src[ret] != '\x1b'); ++ret);
+    return wts8width(src, ret);
+}
+
+cgui::Char::Char(const char* src)
+    : p(src)
+{}
+
+size_t cgui::Char::getSize() const
+{
+    return charSize(p);
+}
+
+size_t cgui::Char::getWidth() const
+{
+    return charWidth(p);
+}
+
 cgui::string::string()
-    : str(defaultColor)
+    : bytes(defaultColor)
 {}
 
 cgui::string::string(const char* in) 
-    : str(in) 
+    : bytes(in)
 {
-    str += defaultColor;
-    calculateVisibleLength();
+    bytes += defaultColor;
+    calculateWidth();
 }
 
 cgui::string::string(std::string_view in) 
@@ -25,23 +77,23 @@ cgui::string::string(size_t count, char c)
 
 size_t cgui::string::size() const 
 { 
-    return str.size();
+    return bytes.size();
 }
 
 size_t cgui::string::length() const 
 { 
-    return visibleLength; 
+    return width; 
 }
 
 const char* cgui::string::data() const
 {
-    return str.data();
+    return bytes.data();
 }
 
 void cgui::string::append(const string& other)
 {
-    str.insert(pushBackPos(), other.str.substr(0, other.pushBackPos()));
-    visibleLength += other.visibleLength;
+    bytes.insert(pushBackPos(), other.bytes.substr(0, other.pushBackPos()));
+    width += other.width;
 }
 
 void cgui::string::pushBack(char other)
@@ -51,8 +103,8 @@ void cgui::string::pushBack(char other)
 
 void cgui::string::insert(size_t pos, const string& other)
 {
-    str.insert(pos, other.str.substr(0, other.pushBackPos()));
-    visibleLength += other.visibleLength;
+    bytes.insert(pos, other.bytes.substr(0, other.pushBackPos()));
+    width += other.width;
 }
 
 void cgui::string::insert(size_t pos, int count, char c)
@@ -62,69 +114,40 @@ void cgui::string::insert(size_t pos, int count, char c)
 
 void cgui::string::appendDirectly(const string& other)
 {
-    str.insert(pushBackPos(), other.str);
-    visibleLength += other.visibleLength;
+    bytes.insert(pushBackPos(), other.bytes);
+    width += other.width;
 }
 
 cgui::string cgui::string::take(size_t n) {
-    cgui::string ret;
-    for (size_t i = 0; i < str.size(); ++i) {
-        ret += str[i];
-        if (str[i] == '\x1b') {
-            for (++i; i < str.size(); ++i) {
-                ret += str[i];
-                if (str[i] == 'm') {
-                    break;
-                }
-            }
-        }
-        ret.calculateVisibleLength();
-        if (ret.length() == n) {
-            return ret;
-        }
+    auto it = begin();
+    size_t currentWidth = 0;
+    for (; (currentWidth < n) && (it != end()); ++it) {
+        currentWidth += charWidth(it);
     }
-    ret.append(string(n - ret.length(), cgui::getPaddingChar()));
-    return ret;
-}
-
-static int utf8CharLength(unsigned char firstByte) {
-    if ((firstByte & 0x80) == 0x00) return 1;
-    else if ((firstByte & 0xE0) == 0xC0) return 2;
-    else if ((firstByte & 0xF0) == 0xE0) return 3;
-    else if ((firstByte & 0xF8) == 0xF0) return 4;
-    else return 0;
+    if (currentWidth == n) {
+        return { std::string(begin().p, it.p).data() };
+    }
+    else if (currentWidth > n) {
+        currentWidth -= charWidth(it);
+    }
+    std::string ret(begin().p, it.p);
+    ret += std::string(n - currentWidth, cgui::getPaddingChar());
+    return { ret.data() };
 }
 
 cgui::string cgui::string::takeComplete(size_t n)
 {
-    cgui::string ret;
-    size_t visibleLength = 0;
-    for (size_t i = 0; i < str.size(); ++i) {
-        ret += str[i];
-        if (str[i] == '\x1b') {
-            for (++i; i < str.size(); ++i) {
-                ret += str[i];
-                if (str[i] == 'm') {
-                    break;
-                }
-            }
-        }
-        else {
-            int utf8Len = utf8CharLength(str[i]);
-            for (int j = 1; j < utf8Len; ++j, ++i) {
-                ret += str[i + 1];
-            }
-            visibleLength++;
-            if (visibleLength == n) {
-                while ((i + 1) < str.size() && (str[i + 1] & 0xC0) == 0x80) {
-                    ret += str[++i];
-                }
-                return ret;
-            }
-        }
+    auto it = begin();
+    size_t currentWidth = 0;
+    for (; (currentWidth < n) && (it != end()); ++it) {
+        currentWidth += charWidth(it);
     }
-    ret.append(string(n - visibleLength, cgui::getPaddingChar()));
-    return ret;
+    if (currentWidth >= n) {
+        return { std::string(begin().p, it.p).data() };
+    }
+    std::string ret(begin().p, it.p);
+    ret += std::string(n - currentWidth, cgui::getPaddingChar());
+    return { ret.data() };
 }
 
 void cgui::string::pushBackDefaultRGB() 
@@ -184,8 +207,8 @@ cgui::string& cgui::string::operator+=(char other)
 
 cgui::string& cgui::string::operator=(const string& other)
 {
-    str = other.str;
-    visibleLength = other.visibleLength;
+    bytes = other.bytes;
+    width = other.width;
     return *this;
 }
 
@@ -194,35 +217,26 @@ cgui::string& cgui::string::operator=(std::string_view other)
     return operator=(string(other));
 }
 
-size_t cgui::string::pushBackPos() const
+cgui::string::iterator cgui::string::begin()
 {
-     return str.end() - str.begin() - defaultColor.size();
+    return { bytes.data() };
 }
 
-void cgui::string::calculateVisibleLength()
+cgui::string::iterator cgui::string::end()
 {
-    visibleLength = 0;
-    // 不能有\n \t
-    // 移除ANSI序列
-    std::string cleanLine = "";
-    for (size_t i = 0; i < str.size(); ++i) {
-        if (str[i] == '\n' || str[i] == '\t') { str[i] = ' '; }
-        else if (str[i] == '\x1b') {
-            for (++i; i < str.size(); ++i) {
-                if (str[i] == 'm') {
-                    break;
-                }
-            }
-            continue;
-        }
-        cleanLine += str[i];
-    }
-    // 处理unicode字符
-    if (!cleanLine.empty()) {
-        visibleLength = wts8width(cleanLine.data(), cleanLine.size());
-    }
-    else {
-        visibleLength = 0;
+    return { bytes.data() + bytes.size() };
+}
+
+size_t cgui::string::pushBackPos() const
+{
+     return bytes.end() - bytes.begin() - defaultColor.size();
+}
+
+void cgui::string::calculateWidth()
+{
+    width = 0;
+    for (auto c : *this) {
+        width += c.getWidth();
     }
 }
 
@@ -239,4 +253,25 @@ cgui::string cgui::operator+(std::string_view lhs, string& rhs)
 cgui::string cgui::operator+(std::string_view lhs, string&& rhs)
 {
     return string(lhs) + rhs;
+}
+
+cgui::string::iterator& cgui::string::iterator::operator++()
+{
+    p += charSize(p);
+    return *this;
+}
+
+bool cgui::string::iterator::operator==(const iterator& other) const
+{
+    return p == other.p;
+}
+
+cgui::Char cgui::string::iterator::operator*() const
+{
+    return Char(p);
+}
+
+cgui::string::iterator::operator char* ()
+{
+    return p;
 }

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -133,11 +133,8 @@ cgui::string cgui::string::takeComplete(size_t n)
         last = it;
         currentWidth += charWidth(it);
     }
-    if (currentWidth == n) {
+    if (currentWidth >= n) {
         return { std::string(begin().p, it.p).data() };
-    }
-    else if (currentWidth > n) {
-        currentWidth -= charWidth(last);
     }
     std::string ret(begin().p, last.p);
     ret += std::string(n - currentWidth, cgui::getPaddingChar());

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -64,6 +64,7 @@ cgui::string::string(const char* in)
     : bytes(in)
 {
     bytes += defaultColor;
+    removeBadChar();
     calculateWidth();
 }
 
@@ -237,6 +238,15 @@ cgui::string::iterator cgui::string::end()
 size_t cgui::string::pushBackPos() const
 {
      return bytes.end() - bytes.begin() - defaultColor.size();
+}
+
+void cgui::string::removeBadChar()
+{
+    for (auto& byte : bytes) {
+        if (byte == '\n' || byte == '\t') {
+            byte = ' ';
+        }
+    }
 }
 
 void cgui::string::calculateWidth()


### PR DESCRIPTION
在cgui::string中添加了迭代器，并用迭代器简化了calculateWidth，take，takeComplete。
把cgui::string private的str改为bytes，visibleLength改为width，使名字更符合直觉。
把calculateVisibleLength分离为removeBadChar和calculateWidth

解决了take中原本的问题：
1.宽度1的utf8字符不该被截取。
2.被截的字符应该用空格取代。
3.改用迭代器后大幅度提高了执行效率。

修复前截图：
![before](https://github.com/user-attachments/assets/1139addb-761a-4f82-bea5-e48a3b1dcb42)
修复后截图：
![after](https://github.com/user-attachments/assets/a08fe096-6712-4654-94d8-4805da658d9f)

另外update中的cout输出，在某些时候会造成奇怪的闪烁，改用printf就解决了，非常神奇的bug。